### PR TITLE
ci: Add linter workflow to dev branch

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -11,10 +11,10 @@ name: ESLint
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   schedule:
     - cron: '33 10 * * 4'
 


### PR DESCRIPTION
ESLint linting workflow will run on commits pushed to dev and PRs raised to dev