### PR TITLE
Regenerate/re-queue scheduled hauntings

### DIFF
--- a/actions/hauntDrivers.js
+++ b/actions/hauntDrivers.js
@@ -29,11 +29,16 @@ module.exports = {
 		}
 		const upcomingSoulType = getWeightedRandomSoulType(guild.id);
 		updateAppearancesWith(nextTimeObj, upcomingSoulType, guildIdString);
+		module.exports.scheduleHaunting(client, guild, upcomingSoulType, nextTimeObj.msUntil);
+	},
+
+	scheduleHaunting: async (client, guild, upcomingSoulType, msUntil) => {
 		setTimeout(() => {
+			const guildData = getGuildData(guild.id);
 			getMemory(client, guild.id).membersWhoFetched = [];
 			hauntSomeChannelWithSoul(guild, upcomingSoulType);
 			if (!guildData.paused) module.exports.guildHauntDriver(client, guild);
-		}, nextTimeObj.msUntil);
+		}, msUntil);
 	},
 
 	regenerateMissedHauntings: async (client) => {

--- a/events/guildquery.js
+++ b/events/guildquery.js
@@ -18,4 +18,12 @@ module.exports = {
 			throw new Error('There was an error pulling server information from the database');
 		}
 	},
+	getAllGuildsData: async () => {
+		try {
+			return await profileModelGuild.find({});
+		} catch (err) {
+			console.log(err);
+			throw new Error('There was an error pulling server information from the database');
+		}
+	},
 };

--- a/functions/souls.js
+++ b/functions/souls.js
@@ -89,6 +89,11 @@ module.exports = {
 		return false;
 	},
 
+	getSoulByIdOrDefault: (soulTypeId, guildId) => {
+		const result = module.exports.getSoulById(soulTypeId, guildId);
+		return result ? result : module.exports.getDefaultSoul();
+	},
+
 	// TODO: revise soul value calculation method
 	getSoulValue: (soul) => {
 		return soul.rarity;

--- a/functions/time.js
+++ b/functions/time.js
@@ -1,7 +1,7 @@
 const dayjs = require('dayjs');
 
-const getRandomizedNextTime = (now, mean = 1440, variation = 6) => {
-	const hoursFromNow = (Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() - 6) * variation / 2 + mean / 60;
+const getRandomizedNextTime = (now, mean = 1440, variation = 5) => {
+	const hoursFromNow = (Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() + Math.random() - 6) * mean / 60 / variation / 2;
 	const nextAppearance = now.add(hoursFromNow, 'hour');
 	return {
 		nextAppearance: nextAppearance,

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const mongoose = require('mongoose');
 const { mongodbsrv } = require('./config.json');
 const { generateDependencyReport } = require('@discordjs/voice');
+const { regenerateMissedHauntings } = require('./actions/hauntDrivers');
 console.log(generateDependencyReport());
 
 // Create a new client instance
@@ -66,3 +67,6 @@ client.memory = null;
 
 // Login to Discord with your client's token
 client.login(token);
+
+// Regenerate missed or otherwise invalid hauntings
+regenerateMissedHauntings(client);

--- a/index.js
+++ b/index.js
@@ -68,5 +68,7 @@ client.memory = null;
 // Login to Discord with your client's token
 client.login(token);
 
-// Regenerate missed or otherwise invalid hauntings
-regenerateMissedHauntings(client);
+client.on('ready', () => {
+	// Regenerate missed or otherwise invalid hauntings
+	regenerateMissedHauntings(client);
+});


### PR DESCRIPTION
Closes #45

Makes a decent fix for #67 but we'll see if we want to adjust that later on

For testing, it's best if you test it by setting the `meanDelay` and `variation` server settings really low, which can be done with the features coming in #58 or by updating it manually in the database. This way the hauntings happen way more often.

If a server had its haunting missed, a new one is regenerated from scratch using the existing `guildHauntDriver` method. If a server did not have its haunting missed (but the bot was turned off between now and when /guildjoin was used) it will queue the haunting for the previously scheduled time using the previously scheduled soul.

Also lays the groundwork for #4, but that refers to the /resume command which is currently unimplemented.