### PR TITLE
Improve serverStats embed's hauntings display, allow admin haunt reroll

### DIFF
--- a/actions/hauntDrivers.js
+++ b/actions/hauntDrivers.js
@@ -29,11 +29,15 @@ module.exports = {
 		}
 		const upcomingSoulType = getWeightedRandomSoulType(guild.id);
 		updateAppearancesWith(nextTimeObj, upcomingSoulType, guildIdString);
+		// Cancel a next haunting setTimeout if it exists
+		if (getMemory(client, guild.id).nextHauntTimeoutId) {
+			clearTimeout(client.memory[guild.id].nextHauntTimeoutId);
+		}
 		module.exports.scheduleHaunting(client, guild, upcomingSoulType, nextTimeObj.msUntil);
 	},
 
 	scheduleHaunting: async (client, guild, upcomingSoulType, msUntil) => {
-		setTimeout(() => {
+		client.memory[guild.id].nextHauntTimeoutId = setTimeout(() => {
 			const guildData = getGuildData(guild.id);
 			getMemory(client, guild.id).membersWhoFetched = [];
 			hauntSomeChannelWithSoul(guild, upcomingSoulType);

--- a/actions/hauntDrivers.js
+++ b/actions/hauntDrivers.js
@@ -1,6 +1,6 @@
 const { hauntSomeChannelWithSoul } = require('./hauntings.js');
 const { getRandomizedNextTimeInFuture } = require('../functions/time.js');
-const { updateAppearancesWith, getMemory } = require('../functions/serverData.js');
+const { updateAppearances, getMemory } = require('../functions/serverData.js');
 const { getWeightedRandomSoulType, getSoulByIdOrDefault } = require('../functions/souls.js');
 const dayjs = require('dayjs');
 const { getGuildData, getAllGuildsData } = require('../events/guildquery');
@@ -28,7 +28,7 @@ module.exports = {
 			console.log(`Override: The server ${guild.name} will be haunted at ${nextTimeObj.nextAppearanceFormatted}`);
 		}
 		const upcomingSoulType = getWeightedRandomSoulType(guild.id);
-		updateAppearancesWith(nextTimeObj, upcomingSoulType, guildIdString, replaceExistingNextOnly);
+		updateAppearances(client, guild.id, nextTimeObj, upcomingSoulType, replaceExistingNextOnly);
 		// Cancel a next haunting setTimeout if it exists
 		if (getMemory(client, guild.id).nextHauntTimeoutId) {
 			clearTimeout(client.memory[guild.id].nextHauntTimeoutId);

--- a/actions/hauntDrivers.js
+++ b/actions/hauntDrivers.js
@@ -37,6 +37,7 @@ module.exports = {
 	},
 
 	scheduleHaunting: async (client, guild, upcomingSoulType, msUntil) => {
+		getMemory(client, guild.id); // Initialize memory if it doesn't exist
 		client.memory[guild.id].nextHauntTimeoutId = setTimeout(() => {
 			const guildData = getGuildData(guild.id);
 			getMemory(client, guild.id).membersWhoFetched = [];

--- a/actions/hauntDrivers.js
+++ b/actions/hauntDrivers.js
@@ -28,22 +28,22 @@ module.exports = {
 			console.log(`Override: The server ${guild.name} will be haunted at ${nextTimeObj.nextAppearanceFormatted}`);
 		}
 		const upcomingSoulType = getWeightedRandomSoulType(guild.id);
-		updateAppearances(client, guild.id, nextTimeObj, upcomingSoulType, replaceExistingNextOnly);
 		// Cancel a next haunting setTimeout if it exists
 		if (getMemory(client, guild.id).nextHauntTimeoutId) {
 			clearTimeout(client.memory[guild.id].nextHauntTimeoutId);
 		}
-		module.exports.scheduleHaunting(client, guild, upcomingSoulType, nextTimeObj.msUntil);
+		module.exports.scheduleHaunting(client, guild, upcomingSoulType, nextTimeObj.nextAppearance, replaceExistingNextOnly);
 	},
 
-	scheduleHaunting: async (client, guild, upcomingSoulType, msUntil) => {
+	scheduleHaunting: async (client, guild, upcomingSoulType, nextAppearance, replaceExistingNextOnly = false) => {
 		getMemory(client, guild.id); // Initialize memory if it doesn't exist
+		updateAppearances(client, guild.id, nextAppearance, upcomingSoulType, replaceExistingNextOnly);
 		client.memory[guild.id].nextHauntTimeoutId = setTimeout(() => {
 			const guildData = getGuildData(guild.id);
 			getMemory(client, guild.id).membersWhoFetched = [];
 			hauntSomeChannelWithSoul(guild, upcomingSoulType);
 			if (!guildData.paused) module.exports.guildHauntDriver(client, guild);
-		}, msUntil);
+		}, Math.abs(dayjs().diff(nextAppearance), 'ms'));
 	},
 
 	regenerateMissedHauntings: async (client) => {
@@ -64,7 +64,7 @@ module.exports = {
 				guild = await guild;
 				console.log(`DEBUG: The server ${guild.name} will have haunting regenerated for ${nextAppearance.format('MM/DD/YYYY hh:mm:ss A')}`);
 				const upcomingSoulType = getSoulByIdOrDefault(guildRecord.schedule.next.soulTypeId);
-				module.exports.scheduleHaunting(client, guild, upcomingSoulType, Math.abs(currentTime.diff(nextAppearance)));
+				module.exports.scheduleHaunting(client, guild, upcomingSoulType, nextAppearance, true);
 			}
 		}
 	},

--- a/buttons/serverStatsButton.js
+++ b/buttons/serverStatsButton.js
@@ -4,7 +4,7 @@ const { getActionRow } = require('../events/getActionRow');
 const { getSoulData } = require('../events/query');
 const { getGuildData } = require('../events/guildquery');
 const profileModel = require ('../models/profileSchema');
-const { getVagueTimeRange } = require('../functions/time');
+const { getMemory } = require('../functions/serverData');
 const dayjs = require('dayjs');
 
 module.exports = {
@@ -24,12 +24,11 @@ module.exports = {
 				allFetchersData.push(allFetchersDataOne[i]);
 			}
 		}
-		let nextTimeData;
+		let nextAppearanceBounds;
 		try {
-			nextTimeData = getVagueTimeRange(guildData.schedule.next.time);
+			nextAppearanceBounds = getMemory(interaction.client, interaction.guild.id).nextAppearanceBounds;
 		} catch (err) {
-			console.error('Error in serverStatsButton: could not get time range: ' + err);
-			return;
+			nextAppearanceBounds = '???';
 		}
 		const pastTime = dayjs(guildData.schedule.past.time).format('MM/DD/YYYY h:mm A');
 
@@ -43,7 +42,7 @@ module.exports = {
 			)
 			.addFields(
 				{ name: '---------------------------------', value: ' ' },
-				{ name: 'Next Appearance ⏭️', value: `Between ${nextTimeData.formatted}` },
+				{ name: 'Next Appearance ⏭️', value: `Between ${nextAppearanceBounds}` },
 				{ name: 'Last Appearance ⏮️', value: `*${pastTime}*` },
 				{ name: '---------------------------------', value: ' ' });
 		

--- a/buttons/serverStatsButton.js
+++ b/buttons/serverStatsButton.js
@@ -30,7 +30,7 @@ module.exports = {
 		} catch (err) {
 			nextAppearanceBounds = '???';
 		}
-		const pastTime = dayjs(guildData.schedule.past.time).format('MM/DD/YYYY h:mm A');
+		const pastTime = guildData.schedule.past.time ? dayjs(guildData.schedule.past.time).format('MM/DD/YYYY h:mm A') : 'None yet...';
 
 		const serverEmbed = new MessageEmbed()
 			.setColor('GREEN')

--- a/buttons/serverStatsButton.js
+++ b/buttons/serverStatsButton.js
@@ -5,6 +5,7 @@ const { getSoulData } = require('../events/query');
 const { getGuildData } = require('../events/guildquery');
 const profileModel = require ('../models/profileSchema');
 const { getVagueTimeRange } = require('../functions/time');
+const dayjs = require('dayjs');
 
 module.exports = {
 	name: 'serverStatsButton',
@@ -30,6 +31,8 @@ module.exports = {
 			console.error('Error in serverStatsButton: could not get time range: ' + err);
 			return;
 		}
+		const pastTime = dayjs(guildData.schedule.past.time).format('MM/DD/YYYY h:mm A');
+
 		const serverEmbed = new MessageEmbed()
 			.setColor('GREEN')
 			.setTitle(`__***${interaction.guild.name}'s Stats***__`)
@@ -41,7 +44,7 @@ module.exports = {
 			.addFields(
 				{ name: '---------------------------------', value: ' ' },
 				{ name: 'Next Appearance ⏭️', value: `Between ${nextTimeData.formatted}` },
-				{ name: 'Last Appearance ⏮️', value: `*${guildData.schedule.past.time}*` },
+				{ name: 'Last Appearance ⏮️', value: `*${pastTime}*` },
 				{ name: '---------------------------------', value: ' ' });
 		
 		try {

--- a/commands/rerollNextHaunt.js
+++ b/commands/rerollNextHaunt.js
@@ -1,0 +1,37 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { isGuildSetup } = require('../functions/isSetup.js');
+const { guildHauntDriver } = require('../actions/hauntDrivers.js');
+const { isMemberDev } = require('../functions/privileges.js');
+const { getGuildData } = require('../events/guildquery.js');
+const dayjs = require('dayjs');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('rerollnexthaunt')
+		.setDescription('For admins, re-roll the next scheduled haunting time.'),
+	async execute(interaction) {
+		if (!await isGuildSetup(interaction)) {
+			interaction.reply({ content: 'This bot has not been setup yet.\n\nTell an admin to use /guildjoin first!', ephemeral: true });
+			return;
+		} else {
+			// Check for admin status (for now only developers have access)
+			if (!isMemberDev(interaction.member.id)) {
+				interaction.reply({ content: 'You must be an admin to use this command!', ephemeral: true });
+				return;
+			}
+
+			const guildData = await getGuildData(interaction.guild.id);
+
+			try {
+				guildHauntDriver(interaction.client, interaction.guild, false, true);
+			} catch (err) {
+				console.error(err);
+				interaction.reply({ content: 'Something went wrong when re-rolling next haunting time.', ephemeral: true });
+				return;
+			}
+			const response = `✅ The upcoming haunting scheduled for **${dayjs(guildData.schedule.next.time).format('MM/DD/YYYY hh:mm:ss A')}** has been re-rolled.`;
+			interaction.reply({ content: response, ephemeral: true });
+			return;
+		}
+	},
+};

--- a/functions/serverData.js
+++ b/functions/serverData.js
@@ -1,4 +1,10 @@
 const { getGuildData } = require('../events/guildquery.js');
+const { getVagueTimeRange } = require('./time.js');
+
+const updateAppearanceBoundsInMemory = async (client, guildIdString, dayjsObj, meanDelay, variation) => {
+	module.exports.getMemory(client, guildIdString); // Ensure memory exists
+	client.memory[guildIdString].nextAppearanceBounds = getVagueTimeRange(dayjsObj.nextAppearance, meanDelay, variation).formatted;
+};
 
 module.exports = {
 	initializeObject: (serverId, condemnedMember, condemnedRoleId, channelId, modRole, meanDelay = 1440, variation = 5) => {
@@ -55,6 +61,8 @@ module.exports = {
 			guildData.schedule.next.time = dayjsObj.nextAppearance.toDate();
 			guildData.schedule.next.soulTypeId = soulType.id;
 			guildData.save();
+
+			updateAppearanceBoundsInMemory(client, guildIdString, dayjsObj, guildData.schedule.meanDelay, guildData.schedule.variation);
 		} catch (err) {
 			console.error(`Error in replaceEarlierAppearance: Could not update information in database for server ${guildIdString}: ${err}`);
 		}

--- a/functions/serverData.js
+++ b/functions/serverData.js
@@ -1,9 +1,9 @@
 const { getGuildData } = require('../events/guildquery.js');
 const { getVagueTimeRange } = require('./time.js');
 
-const updateAppearanceBoundsInMemory = async (client, guildIdString, dayjsObj, meanDelay, variation) => {
+const updateAppearanceBoundsInMemory = async (client, guildIdString, nextAppearance, meanDelay, variation) => {
 	module.exports.getMemory(client, guildIdString); // Ensure memory exists
-	client.memory[guildIdString].nextAppearanceBounds = getVagueTimeRange(dayjsObj.nextAppearance, meanDelay, variation).formatted;
+	client.memory[guildIdString].nextAppearanceBounds = getVagueTimeRange(nextAppearance, meanDelay, variation).formatted;
 };
 
 module.exports = {
@@ -54,15 +54,15 @@ module.exports = {
 		}
 	},
 
-	updateAppearances: async (client, guildIdString, dayjsObj, soulType, replaceExistingNextOnly = false) => {
+	updateAppearances: async (client, guildIdString, nextAppearance, soulType, replaceExistingNextOnly = false) => {
 		try {
 			const guildData = await getGuildData(guildIdString);
 			if (!replaceExistingNextOnly) guildData.schedule.past = guildData.schedule.next;
-			guildData.schedule.next.time = dayjsObj.nextAppearance.toDate();
+			guildData.schedule.next.time = nextAppearance.toDate();
 			guildData.schedule.next.soulTypeId = soulType.id;
 			guildData.save();
 
-			updateAppearanceBoundsInMemory(client, guildIdString, dayjsObj, guildData.schedule.meanDelay, guildData.schedule.variation);
+			updateAppearanceBoundsInMemory(client, guildIdString, nextAppearance, guildData.schedule.meanDelay, guildData.schedule.variation);
 		} catch (err) {
 			console.error(`Error in replaceEarlierAppearance: Could not update information in database for server ${guildIdString}: ${err}`);
 		}

--- a/functions/serverData.js
+++ b/functions/serverData.js
@@ -48,10 +48,10 @@ module.exports = {
 		}
 	},
 
-	updateAppearancesWith: async (dayjsObj, soulType, guildIdString) => {
+	updateAppearancesWith: async (dayjsObj, soulType, guildIdString, nextBecomesPast = true) => {
 		try {
 			const guildData = await getGuildData(guildIdString);
-			guildData.schedule.past = guildData.schedule.next;
+			if (nextBecomesPast) guildData.schedule.past = guildData.schedule.next;
 			guildData.schedule.next.time = dayjsObj.nextAppearance.toDate();
 			guildData.schedule.next.soulTypeId = soulType.id;
 			guildData.save();

--- a/functions/serverData.js
+++ b/functions/serverData.js
@@ -48,7 +48,7 @@ module.exports = {
 		}
 	},
 
-	updateAppearancesWith: async (dayjsObj, soulType, guildIdString, replaceExistingNextOnly = false) => {
+	updateAppearances: async (client, guildIdString, dayjsObj, soulType, replaceExistingNextOnly = false) => {
 		try {
 			const guildData = await getGuildData(guildIdString);
 			if (!replaceExistingNextOnly) guildData.schedule.past = guildData.schedule.next;

--- a/functions/serverData.js
+++ b/functions/serverData.js
@@ -48,10 +48,10 @@ module.exports = {
 		}
 	},
 
-	updateAppearancesWith: async (dayjsObj, soulType, guildIdString, nextBecomesPast = true) => {
+	updateAppearancesWith: async (dayjsObj, soulType, guildIdString, replaceExistingNextOnly = false) => {
 		try {
 			const guildData = await getGuildData(guildIdString);
-			if (nextBecomesPast) guildData.schedule.past = guildData.schedule.next;
+			if (!replaceExistingNextOnly) guildData.schedule.past = guildData.schedule.next;
 			guildData.schedule.next.time = dayjsObj.nextAppearance.toDate();
 			guildData.schedule.next.soulTypeId = soulType.id;
 			guildData.save();


### PR DESCRIPTION
Closes #65, #66, #69

Also fixes an unnoticed issue with regenerating missed hauntings: those will now no longer show the missed haunting time as the past haunting when a new one is scheduled, since it never actually occurred. For example, if there was a haunting at 2pm and there was another one scheduled for 4pm that never happened because the bot was offline, when it comes back online it might regenerate the next haunting for 7pm but will still say the previous haunting was at 2pm instead of saying the previous was at 4pm.

No breaking changes to the rest of the codebase but many existing methods had signatures refactored